### PR TITLE
feat: add start indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
       },
       "devDependencies": {
         "@hapi/hapi": "^21.3.12",
-        "@types/node": "^22.9.3",
-        "@types/tape": "^5.6.4",
+        "@types/node": "^22.10.1",
+        "@types/tape": "^5.6.5",
         "audit-ci": "^7.1.0",
         "debug": "4.3.7",
         "joi": "^17.13.3",
@@ -1133,13 +1133,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.3.tgz",
-      "integrity": "sha512-F3u1fs/fce3FFk+DAxbxc78DF8x0cY09RRL8GnXLmkJ1jvx3TtPdWoTT5/NiYfI5ASqXBmfqJi9dZ3gxMx4lzw==",
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1155,21 +1155,13 @@
       "dev": true
     },
     "node_modules/@types/tape": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@types/tape/-/tape-5.6.4.tgz",
-      "integrity": "sha512-EmL4fJpZyByNCkupLLcJhneqcnT+rQUG5fWKNCsZyBK1x7nUuDTwwEerc4biEMZgvSK2+FXr775aLeXhKXK4Yw==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/tape/-/tape-5.6.5.tgz",
+      "integrity": "sha512-/Eer3ugx8wLoJ4FFD2QzAO2RjuAys60WzvnVhOREHg+EGazbae9N095pLPGhDRErBkngl8YjZ1hApQ79UHraaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "*",
-        "@types/through": "*"
-      }
-    },
-    "node_modules/@types/through": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
-      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
-      "dev": true,
-      "dependencies": {
+        "@ljharb/through": "*",
         "@types/node": "*"
       }
     },
@@ -9777,10 +9769,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
   },
   "devDependencies": {
     "@hapi/hapi": "^21.3.12",
-    "@types/node": "^22.9.3",
-    "@types/tape": "^5.6.4",
+    "@types/node": "^22.10.1",
+    "@types/tape": "^5.6.5",
     "audit-ci": "^7.1.0",
     "debug": "4.3.7",
     "joi": "^17.13.3",


### PR DESCRIPTION
This enables easy tracking of when each service started, giving possibility to improve the dashboards for spotting of events like:
- restarts simulated by HA test tools like chaos-mesh
- restarts due to upgrades
- restarts due to OOM errors
- scaling replicas